### PR TITLE
feat(interactions): ✨ more skill calculator sorting strategies

### DIFF
--- a/data/tasks/fishing.json
+++ b/data/tasks/fishing.json
@@ -9,11 +9,9 @@
     "rewards": {
       "skillExperience": 2,
       "vendorGold": 2,
-      "statisticExperiences": [
-        {
-          "dexterity": 1
-        }
-      ]
+      "statisticExperiences": {
+        "dexterity": 1
+      }
     }
   },
   {
@@ -26,11 +24,9 @@
     "rewards": {
       "skillExperience": 4,
       "vendorGold": 3,
-      "statisticExperiences": [
-        {
-          "dexterity": 2
-        }
-      ]
+      "statisticExperiences": {
+        "dexterity": 2
+      }
     }
   },
   {
@@ -43,11 +39,9 @@
     "rewards": {
       "skillExperience": 6,
       "vendorGold": 4,
-      "statisticExperiences": [
-        {
-          "dexterity": 3
-        }
-      ]
+      "statisticExperiences": {
+        "dexterity": 3
+      }
     }
   },
   {
@@ -60,11 +54,9 @@
     "rewards": {
       "skillExperience": 8,
       "vendorGold": 5,
-      "statisticExperiences": [
-        {
-          "dexterity": 4
-        }
-      ]
+      "statisticExperiences": {
+        "dexterity": 4
+      }
     }
   },
   {
@@ -77,11 +69,9 @@
     "rewards": {
       "skillExperience": 10,
       "vendorGold": 6,
-      "statisticExperiences": [
-        {
-          "dexterity": 5
-        }
-      ]
+      "statisticExperiences": {
+        "dexterity": 5
+      }
     }
   },
   {
@@ -94,11 +84,9 @@
     "rewards": {
       "skillExperience": 13,
       "vendorGold": 7,
-      "statisticExperiences": [
-        {
-          "dexterity": 6
-        }
-      ]
+      "statisticExperiences": {
+        "dexterity": 6
+      }
     }
   },
   {
@@ -111,11 +99,9 @@
     "rewards": {
       "skillExperience": 16,
       "vendorGold": 8,
-      "statisticExperiences": [
-        {
-          "dexterity": 7
-        }
-      ]
+      "statisticExperiences": {
+        "dexterity": 7
+      }
     }
   },
   {
@@ -128,11 +114,9 @@
     "rewards": {
       "skillExperience": 19,
       "vendorGold": 14,
-      "statisticExperiences": [
-        {
-          "dexterity": 9
-        }
-      ]
+      "statisticExperiences": {
+        "dexterity": 9
+      }
     }
   },
   {
@@ -145,11 +129,9 @@
     "rewards": {
       "skillExperience": 22,
       "vendorGold": 16,
-      "statisticExperiences": [
-        {
-          "dexterity": 10
-        }
-      ]
+      "statisticExperiences": {
+        "dexterity": 10
+      }
     }
   },
   {
@@ -162,11 +144,9 @@
     "rewards": {
       "skillExperience": 27,
       "vendorGold": 20,
-      "statisticExperiences": [
-        {
-          "dexterity": 11
-        }
-      ]
+      "statisticExperiences": {
+        "dexterity": 11
+      }
     }
   },
   {
@@ -179,11 +159,9 @@
     "rewards": {
       "skillExperience": 35,
       "vendorGold": 23,
-      "statisticExperiences": [
-        {
-          "dexterity": 12
-        }
-      ]
+      "statisticExperiences": {
+        "dexterity": 12
+      }
     }
   },
   {
@@ -196,11 +174,9 @@
     "rewards": {
       "skillExperience": 40,
       "vendorGold": 35,
-      "statisticExperiences": [
-        {
-          "dexterity": 14
-        }
-      ]
+      "statisticExperiences": {
+        "dexterity": 14
+      }
     }
   },
   {
@@ -213,11 +189,9 @@
     "rewards": {
       "skillExperience": 63,
       "vendorGold": 45,
-      "statisticExperiences": [
-        {
-          "dexterity": 20
-        }
-      ]
+      "statisticExperiences": {
+        "dexterity": 20
+      }
     }
   }
 ]

--- a/data/tasks/mining.json
+++ b/data/tasks/mining.json
@@ -8,12 +8,10 @@
     "rewards": {
       "skillExperience": 3,
       "vendorGold": 1,
-      "statisticExperiences": [
-        {
-          "strength": 1,
-          "defense": 1
-        }
-      ]
+      "statisticExperiences": {
+        "strength": 1,
+        "defence": 1
+      }
     }
   },
   {
@@ -25,12 +23,10 @@
     "rewards": {
       "skillExperience": 3,
       "vendorGold": 1,
-      "statisticExperiences": [
-        {
-          "strength": 1,
-          "defense": 1
-        }
-      ]
+      "statisticExperiences": {
+        "strength": 1,
+        "defence": 1
+      }
     }
   },
   {
@@ -42,12 +38,10 @@
     "rewards": {
       "skillExperience": 5,
       "vendorGold": 2,
-      "statisticExperiences": [
-        {
-          "strength": 1,
-          "defense": 2
-        }
-      ]
+      "statisticExperiences": {
+        "strength": 1,
+        "defence": 2
+      }
     }
   },
   {
@@ -59,12 +53,10 @@
     "rewards": {
       "skillExperience": 10,
       "vendorGold": 3,
-      "statisticExperiences": [
-        {
-          "strength": 2,
-          "defense": 3
-        }
-      ]
+      "statisticExperiences": {
+        "strength": 2,
+        "defence": 3
+      }
     }
   },
   {
@@ -76,12 +68,10 @@
     "rewards": {
       "skillExperience": 15,
       "vendorGold": 5,
-      "statisticExperiences": [
-        {
-          "strength": 3,
-          "defense": 5
-        }
-      ]
+      "statisticExperiences": {
+        "strength": 3,
+        "defence": 5
+      }
     }
   },
   {
@@ -93,12 +83,10 @@
     "rewards": {
       "skillExperience": 21,
       "vendorGold": 7,
-      "statisticExperiences": [
-        {
-          "strength": 3,
-          "defense": 7
-        }
-      ]
+      "statisticExperiences": {
+        "strength": 3,
+        "defence": 7
+      }
     }
   },
   {
@@ -110,12 +98,10 @@
     "rewards": {
       "skillExperience": 27,
       "vendorGold": 9,
-      "statisticExperiences": [
-        {
-          "strength": 4,
-          "defense": 9
-        }
-      ]
+      "statisticExperiences": {
+        "strength": 4,
+        "defence": 9
+      }
     }
   },
   {
@@ -127,12 +113,10 @@
     "rewards": {
       "skillExperience": 35,
       "vendorGold": 11,
-      "statisticExperiences": [
-        {
-          "strength": 5,
-          "defense": 11
-        }
-      ]
+      "statisticExperiences": {
+        "strength": 5,
+        "defence": 11
+      }
     }
   },
   {
@@ -144,12 +128,10 @@
     "rewards": {
       "skillExperience": 40,
       "vendorGold": 13,
-      "statisticExperiences": [
-        {
-          "strength": 6,
-          "defense": 13
-        }
-      ]
+      "statisticExperiences": {
+        "strength": 6,
+        "defence": 13
+      }
     }
   },
   {
@@ -161,12 +143,10 @@
     "rewards": {
       "skillExperience": 55,
       "vendorGold": 15,
-      "statisticExperiences": [
-        {
-          "strength": 7,
-          "defense": 16
-        }
-      ]
+      "statisticExperiences": {
+        "strength": 7,
+        "defence": 16
+      }
     }
   }
 ]

--- a/data/tasks/woodcutting.json
+++ b/data/tasks/woodcutting.json
@@ -8,11 +8,9 @@
     "rewards": {
       "skillExperience": 3,
       "vendorGold": 1,
-      "statisticExperiences": [
-        {
-          "strength": 1
-        }
-      ]
+      "statisticExperiences": {
+        "strength": 1
+      }
     }
   },
   {
@@ -24,11 +22,9 @@
     "rewards": {
       "skillExperience": 5,
       "vendorGold": 2,
-      "statisticExperiences": [
-        {
-          "strength": 2
-        }
-      ]
+      "statisticExperiences": {
+        "strength": 2
+      }
     }
   },
   {
@@ -40,11 +36,9 @@
     "rewards": {
       "skillExperience": 10,
       "vendorGold": 3,
-      "statisticExperiences": [
-        {
-          "strength": 3
-        }
-      ]
+      "statisticExperiences": {
+        "strength": 3
+      }
     }
   },
   {
@@ -56,11 +50,9 @@
     "rewards": {
       "skillExperience": 15,
       "vendorGold": 5,
-      "statisticExperiences": [
-        {
-          "strength": 5
-        }
-      ]
+      "statisticExperiences": {
+        "strength": 5
+      }
     }
   },
   {
@@ -72,11 +64,9 @@
     "rewards": {
       "skillExperience": 21,
       "vendorGold": 7,
-      "statisticExperiences": [
-        {
-          "strength": 7
-        }
-      ]
+      "statisticExperiences": {
+        "strength": 7
+      }
     }
   },
   {
@@ -88,11 +78,9 @@
     "rewards": {
       "skillExperience": 27,
       "vendorGold": 9,
-      "statisticExperiences": [
-        {
-          "strength": 9
-        }
-      ]
+      "statisticExperiences": {
+        "strength": 9
+      }
     }
   },
   {
@@ -104,11 +92,9 @@
     "rewards": {
       "skillExperience": 35,
       "vendorGold": 11,
-      "statisticExperiences": [
-        {
-          "strength": 11
-        }
-      ]
+      "statisticExperiences": {
+        "strength": 11
+      }
     }
   },
   {
@@ -120,11 +106,9 @@
     "rewards": {
       "skillExperience": 40,
       "vendorGold": 13,
-      "statisticExperiences": [
-        {
-          "strength": 13
-        }
-      ]
+      "statisticExperiences": {
+        "strength": 13
+      }
     }
   },
   {
@@ -136,11 +120,9 @@
     "rewards": {
       "skillExperience": 55,
       "vendorGold": 15,
-      "statisticExperiences": [
-        {
-          "strength": 16
-        }
-      ]
+      "statisticExperiences": {
+        "strength": 16
+      }
     }
   }
 ]

--- a/src/config/enums.ts
+++ b/src/config/enums.ts
@@ -9,6 +9,7 @@ export const enum ActionNames {
 export const enum ErrorMessages {
   LevelInformationNotFound = 'Level information could not be found.',
   SkillCalulatorIncoherentLevels = 'Target level must be higher than the base level.',
+  SkillCalculatorNoOutputTaskAvailable = 'No output task available.',
   SkillCalculatorSkillNotYetImplemented = 'Skill is not yet implemented.',
   SlashCommandArgumentsMalformed = 'Slash command arguments are malformed.',
 }
@@ -48,8 +49,12 @@ export const enum SkillNames {
 }
 
 export const enum SkillCalculatorSortingStrategies {
-  ExperiencePerHour = 'experience_per_hour',
+  DefenceExperiencePerHour = 'defence_experience_per_hour',
+  DexterityExperiencePerHour = 'dexterity_experience_per_hour',
   GoldPerHour = 'gold_per_hour',
+  SkillExperiencePerHour = 'skill_experience_per_hour',
+  SpeedExperiencePerHour = 'speed_experience_per_hour',
+  StrengthExperiencePerHour = 'strength_experience_per_hour',
 }
 
 export const enum StatisticNames {

--- a/src/interactions/skillCalculator/callback.ts
+++ b/src/interactions/skillCalculator/callback.ts
@@ -19,8 +19,14 @@ import type {
   SkillCalculatorArguments,
   SkillCalculatorTaskBonuses,
 } from '../../types/interactions.js'
-import type { SkillTask, SkillTaskYield } from '../../types/maps.js'
+import type {
+  SkillTask,
+  SkillTaskRewards,
+  SkillTaskRewardsYield,
+  SkillTaskYield,
+} from '../../types/maps.js'
 import { experienceBetweenLevels } from '../../utils/maths.js'
+import { snakeCaseToCamelCaseString } from '../../utils/strings.js'
 
 import { skillCalculatorResultsEmbed } from './embed.js'
 
@@ -62,55 +68,60 @@ const computeRankedTasks = (
   taskBonuses: SkillCalculatorTaskBonuses,
   sortingStrategy: SkillCalculatorSortingStrategies,
 ): SkillTaskYield[] => {
-  const sortingStrategies = {
-    [SkillCalculatorSortingStrategies.ExperiencePerHour]: (
-      a: SkillTaskYield,
-      b: SkillTaskYield,
-    ) => {
-      return b.experiencePerHour - a.experiencePerHour
-    },
-    [SkillCalculatorSortingStrategies.GoldPerHour]: (
-      a: SkillTaskYield,
-      b: SkillTaskYield,
-    ) => {
-      return b.goldPerHour - a.goldPerHour
-    },
-  }
+  const sortingKey =
+    snakeCaseToCamelCaseString<
+      Exclude<
+        keyof SkillTaskRewardsYield,
+        keyof SkillTaskRewards | 'itemsPerHour'
+      >
+    >(sortingStrategy)
 
   return tasks
     .map((task): SkillTaskYield => {
       const timeToCompleteWithBonuses =
         task.timeToComplete / (1 + taskBonuses.reductionTimeRatio)
+      const skillExperienceWithBonuses = Math.floor(
+        task.rewards.skillExperience * taskBonuses.bonusExperienceRatio,
+      )
+
+      const goldCost = task.goldCost ?? 0
 
       const itemsPerHour = Math.floor(
         Constants.MillisecondsInHour / timeToCompleteWithBonuses,
       )
-
-      const skillExperienceWithBonuses = Math.floor(
-        task.rewards.skillExperience * taskBonuses.bonusExperienceRatio,
-      )
-      const experiencePerHour = itemsPerHour * skillExperienceWithBonuses
-
-      const goldCost = task.goldCost ?? 0
+      const skillExperiencePerHour = itemsPerHour * skillExperienceWithBonuses
       const goldPerHour =
         itemsPerHour *
         (Math.round(task.rewards.vendorGold * taskBonuses.barteringRatio) -
           goldCost)
 
+      const defenceExperiencePerHour =
+        itemsPerHour * (task.rewards.statisticExperiences.defence ?? 0)
+      const dexterityExperiencePerHour =
+        itemsPerHour * (task.rewards.statisticExperiences.dexterity ?? 0)
+      const strengthExperiencePerHour =
+        itemsPerHour * (task.rewards.statisticExperiences.strength ?? 0)
+      const speedExperiencePerHour =
+        itemsPerHour * (task.rewards.statisticExperiences.speed ?? 0)
+
       return {
         ...task,
-        experiencePerHour,
-        goldPerHour,
-        itemsPerHour,
         rewards: {
           ...task.rewards,
-          skillExperienceWithBonuses,
+          defenceExperiencePerHour,
+          dexterityExperiencePerHour,
+          goldPerHour,
+          itemsPerHour,
+          skillExperiencePerHour,
+          speedExperiencePerHour,
+          strengthExperiencePerHour,
         },
+        skillExperienceWithBonuses,
         timeToCompleteWithBonuses,
       }
     })
     .sort((a, b) => {
-      return sortingStrategies[sortingStrategy](a, b)
+      return b.rewards[sortingKey] - a.rewards[sortingKey]
     })
 }
 
@@ -128,20 +139,38 @@ const prepareDataForEmbed = (
     sortingStrategy,
     targetLevel: commandArguments.targetLevel,
     tasks: {
-      experiencePerHour: [],
+      defenceExperiencePerHour: [],
+      dexterityExperiencePerHour: [],
       goldPerHour: [],
       names: [],
       itemsPerHour: [],
+      skillExperiencePerHour: [],
+      speedExperiencePerHour: [],
+      strengthExperiencePerHour: [],
     },
     timeToTargetLevel: '',
     toolBonus: commandArguments.toolBonus ?? 0,
   }
 
   for (const task of rankedTasks) {
+    embedData.tasks.defenceExperiencePerHour.push(
+      task.rewards.defenceExperiencePerHour,
+    )
+    embedData.tasks.dexterityExperiencePerHour.push(
+      task.rewards.dexterityExperiencePerHour,
+    )
+    embedData.tasks.skillExperiencePerHour.push(
+      task.rewards.skillExperiencePerHour,
+    )
+    embedData.tasks.goldPerHour.push(task.rewards.goldPerHour)
+    embedData.tasks.itemsPerHour.push(task.rewards.itemsPerHour)
     embedData.tasks.names.push(`${task.emoji} ${task.label}`)
-    embedData.tasks.experiencePerHour.push(task.experiencePerHour)
-    embedData.tasks.goldPerHour.push(task.goldPerHour)
-    embedData.tasks.itemsPerHour.push(task.itemsPerHour)
+    embedData.tasks.speedExperiencePerHour.push(
+      task.rewards.speedExperiencePerHour,
+    )
+    embedData.tasks.strengthExperiencePerHour.push(
+      task.rewards.strengthExperiencePerHour,
+    )
   }
 
   const experienceToGain = experienceBetweenLevels(
@@ -149,9 +178,14 @@ const prepareDataForEmbed = (
     commandArguments.targetLevel,
     commandArguments.baseLevelRemainingExperience,
   )
-  const bestTask = rankedTasks.at(0) as SkillTaskYield
+  const bestTask = rankedTasks.at(0)
+
+  if (!bestTask) {
+    throw new InternalError(ErrorMessages.SkillCalculatorNoOutputTaskAvailable)
+  }
+
   const numberOfItemsNeeded = Math.ceil(
-    experienceToGain / bestTask.rewards.skillExperienceWithBonuses,
+    experienceToGain / bestTask.skillExperienceWithBonuses,
   )
 
   embedData.timeToTargetLevel = millisecondsToTimeString(
@@ -196,7 +230,7 @@ export const skillCalculatorCallback = async (
   const taskBonuses = computeTaskBonuses(commandArguments)
   const sortingStrategy =
     commandArguments.sortingStrategy ??
-    SkillCalculatorSortingStrategies.ExperiencePerHour
+    SkillCalculatorSortingStrategies.SkillExperiencePerHour
 
   const rankedTasks = computeRankedTasks(
     doableTasks,

--- a/src/interactions/skillCalculator/command.ts
+++ b/src/interactions/skillCalculator/command.ts
@@ -91,12 +91,28 @@ export const skillCalculatorCommand = new SlashCommandBuilder()
       .setDescription(OptionDescriptions.SortingStrategy)
       .addChoices(
         {
-          name: 'Experience per hour',
-          value: SkillCalculatorSortingStrategies.ExperiencePerHour,
+          name: 'Defence experience',
+          value: SkillCalculatorSortingStrategies.DefenceExperiencePerHour,
         },
         {
-          name: 'Gold per hour',
+          name: 'Dexterity experience',
+          value: SkillCalculatorSortingStrategies.DexterityExperiencePerHour,
+        },
+        {
+          name: 'Skill experience',
+          value: SkillCalculatorSortingStrategies.SkillExperiencePerHour,
+        },
+        {
+          name: 'Gold',
           value: SkillCalculatorSortingStrategies.GoldPerHour,
+        },
+        {
+          name: 'Speed experience',
+          value: SkillCalculatorSortingStrategies.SpeedExperiencePerHour,
+        },
+        {
+          name: 'Strength experience',
+          value: SkillCalculatorSortingStrategies.StrengthExperiencePerHour,
         },
       )
   })

--- a/src/interactions/skillCalculator/embed.ts
+++ b/src/interactions/skillCalculator/embed.ts
@@ -6,27 +6,35 @@ import { SkillCalculatorSortingStrategies } from '../../config/enums.js'
 import { bonusEssences } from '../../config/maps.js'
 import type { SkillCalculatorResultsEmbedData } from '../../types/embeds.js'
 import { emptyField } from '../../utils/embeds.js'
+import { snakeCaseToCamelCaseString } from '../../utils/strings.js'
 
 const strategyField = (
   data: SkillCalculatorResultsEmbedData,
 ): APIEmbedField => {
-  if (
-    data.sortingStrategy === SkillCalculatorSortingStrategies.ExperiencePerHour
-  ) {
-    return {
-      name: ':sparkles: XP/Hour',
-      value: data.tasks.experiencePerHour
-        .map((entry) => {
-          return entry.toLocaleString('en')
-        })
-        .join('\n'),
-      inline: true,
-    }
+  const sortingKey = snakeCaseToCamelCaseString<
+    Exclude<
+      keyof SkillCalculatorResultsEmbedData['tasks'],
+      'names' | 'itemsPerHour'
+    >
+  >(data.sortingStrategy)
+
+  const fieldNames = {
+    [SkillCalculatorSortingStrategies.DefenceExperiencePerHour]:
+      '<:defence:1195777361673715773> Defence XP/Hour',
+    [SkillCalculatorSortingStrategies.DexterityExperiencePerHour]:
+      '<:dexterity:1195777350407827527> Dexterity XP/Hour',
+    [SkillCalculatorSortingStrategies.GoldPerHour]: ':coin: Gold/Hour',
+    [SkillCalculatorSortingStrategies.SkillExperiencePerHour]:
+      ':sparkles: Skill XP/Hour',
+    [SkillCalculatorSortingStrategies.SpeedExperiencePerHour]:
+      '<:speed:1195777352299466763> Speed XP/Hour',
+    [SkillCalculatorSortingStrategies.StrengthExperiencePerHour]:
+      '<:strength:1195777362906857604> Strength XP/Hour',
   }
 
   return {
-    name: ':coin: Gold/Hour',
-    value: data.tasks.goldPerHour
+    name: fieldNames[data.sortingStrategy],
+    value: data.tasks[sortingKey]
       .map((entry) => {
         return entry.toLocaleString('en')
       })
@@ -119,7 +127,7 @@ export const skillCalculatorResultsEmbed = (
   return baseEmded()
     .setTitle(`Skill Calculator | ${capitalizeString(data.skillName)}`)
     .setDescription(
-      `Tasks are sorted by **XP/hour** rate in descending order. Time is computed assuming you run the most efficient task for the whole duration.\n\u200B`,
+      `Time is computed assuming you run the most efficient task based on the sorting strategy you've selected for the whole duration.\n\u200B`,
     )
     .setFields([
       timeEstimateField(data),

--- a/src/types/embeds.ts
+++ b/src/types/embeds.ts
@@ -12,10 +12,14 @@ export interface SkillCalculatorResultsEmbedData {
   sortingStrategy: SkillCalculatorSortingStrategies
   targetLevel: number
   tasks: {
-    experiencePerHour: number[]
+    defenceExperiencePerHour: number[]
+    dexterityExperiencePerHour: number[]
     goldPerHour: number[]
     itemsPerHour: number[]
+    skillExperiencePerHour: number[]
     names: string[]
+    speedExperiencePerHour: number[]
+    strengthExperiencePerHour: number[]
   }
   timeToTargetLevel: string
   toolBonus: number

--- a/src/types/maps.ts
+++ b/src/types/maps.ts
@@ -2,7 +2,7 @@ import type { StatisticNames } from '../config/enums.js'
 
 export interface SkillTaskRewards {
   skillExperience: number
-  statisticExperiences: Array<Partial<Record<StatisticNames, number>>>
+  statisticExperiences: { [key in StatisticNames]?: number }
   vendorGold: number
 }
 

--- a/src/types/maps.ts
+++ b/src/types/maps.ts
@@ -18,12 +18,16 @@ export interface SkillTask {
 }
 
 export interface SkillTaskRewardsYield extends SkillTaskRewards {
-  skillExperienceWithBonuses: number
-}
-export interface SkillTaskYield extends SkillTask {
-  experiencePerHour: number
+  defenceExperiencePerHour: number
+  dexterityExperiencePerHour: number
   goldPerHour: number
   itemsPerHour: number
+  skillExperiencePerHour: number
+  speedExperiencePerHour: number
+  strengthExperiencePerHour: number
+}
+export interface SkillTaskYield extends SkillTask {
+  skillExperienceWithBonuses: number
   rewards: SkillTaskRewardsYield
   timeToCompleteWithBonuses: number
 }

--- a/src/utils/strings.ts
+++ b/src/utils/strings.ts
@@ -1,0 +1,7 @@
+export const snakeCaseToCamelCaseString = <T extends string = string>(
+  snakeCaseString: string,
+): T => {
+  return snakeCaseString.replaceAll(/_([\da-z])/g, (_, letter) => {
+    return letter.toUpperCase()
+  }) as T
+}


### PR DESCRIPTION
## :book: Description

<!--
  Describe your changes in detail.
-->

As the system holds each task statistic experience yield, including more sorting strategies based on those statistic could be a nice to have.

This pull request implements 4 new sorting strategies:
- Defence XP/hour
- Dexterity XP/hour
- Speed XP/hour
- Strength XP/hour

## :ticket: Related Issue(s)

<!--
  Mention Issues related to this Pull Request with the following format:
  Fixes: #1, #2, ... and #N.
-->

#22 
## :clipboard: Checklist

<!--
To be merged, your Pull Request must pass all the following checks.
-->

- [x] I have added the right labels to this Pull Request
- [x] I have performed a self-review of my code
- [x] If needed, I updated the documentation accordingly
- [x] For bug fixes or features, I added some tests
- [x] All existing and new tests pass successfully

